### PR TITLE
Generalized naming of classes that aren't exclusive to Mobile Services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ sysinfo.txt
 
 # OS generated
 .DS_Store
+
+# Visual Studio and Visual Studio Code Settings
+.vscode/
+.vs/

--- a/Assets/AppServices/authentication/AppServiceAuthenticationProvider.cs
+++ b/Assets/AppServices/authentication/AppServiceAuthenticationProvider.cs
@@ -1,6 +1,6 @@
 ﻿namespace Unity3dAzure.AppServices
 {
-	public enum MobileServiceAuthenticationProvider
+	public enum AppServiceAuthenticationProvider
 	{
 		MicrosoftAccount = 0,
 		Google = 1,

--- a/Assets/AppServices/client/AppServiceClient.cs
+++ b/Assets/AppServices/client/AppServiceClient.cs
@@ -13,18 +13,18 @@ using System.Net.Security;
 
 namespace Unity3dAzure.AppServices
 {
-	public class MobileServiceClient : IAzureMobileServiceClient
+	public class AppServiceClient : IAppServiceClient
 	{
 		public string AppUrl { get; private set; }
 
-		public MobileServiceUser User { get; set; }
+		public AppServiceUser User { get; set; }
 
 		public const string URI_API = "api/";
 
 		/// <summary>
 		/// Creates a new RestClient using Azure App Service's Application Url
 		/// </summary>
-		public MobileServiceClient (string appUrl)
+		public AppServiceClient (string appUrl)
 		{
 			AppUrl = HttpsUri (appUrl);
 			Debug.Log ("App Url: " + AppUrl);
@@ -49,7 +49,7 @@ namespace Unity3dAzure.AppServices
 		/// <summary>
 		/// Client-directed single sign on (POST with access token)
 		/// </summary>
-		public IEnumerator Login (MobileServiceAuthenticationProvider provider, string token, Action<IRestResponse<MobileServiceUser>> callback = null)
+		public IEnumerator Login (AppServiceAuthenticationProvider provider, string token, Action<IRestResponse<AppServiceUser>> callback = null)
 		{
 			string p = provider.ToString ().ToLower ();
 			string url = string.Format ("{0}/.auth/login/{1}", AppUrl, p);
@@ -57,7 +57,7 @@ namespace Unity3dAzure.AppServices
 			ZumoRequest request = new ZumoRequest (this, url, Method.POST);
 			request.AddBodyAccessToken (token);
 			yield return request.request.Send ();
-			request.ParseJson<MobileServiceUser> (callback);
+			request.ParseJson<AppServiceUser> (callback);
 		}
 
 		/// <summary>

--- a/Assets/AppServices/client/IAppServiceClient.cs
+++ b/Assets/AppServices/client/IAppServiceClient.cs
@@ -3,7 +3,7 @@ using System.Collections;
 
 namespace Unity3dAzure.AppServices
 {
-	public interface IAzureMobileServiceClient
+	public interface IAppServiceClient
 	{
 		MobileServiceTable<E> GetTable<E> (string tableName) where E : class;
 
@@ -11,7 +11,7 @@ namespace Unity3dAzure.AppServices
 		/// Client-directed login (sdk) for single sign on
 		/// https://msdn.microsoft.com/en-us/library/azure/jj710106.aspx
 		/// </summary>
-		IEnumerator Login (MobileServiceAuthenticationProvider provider, string token, Action<IRestResponse<MobileServiceUser>> callback = null);
+		IEnumerator Login (AppServiceAuthenticationProvider provider, string token, Action<IRestResponse<AppServiceUser>> callback = null);
 
 		/// <summary>
 		/// TODO: Service-directed login (webview)

--- a/Assets/AppServices/http/ZumoRequest.cs
+++ b/Assets/AppServices/http/ZumoRequest.cs
@@ -4,7 +4,7 @@ namespace Unity3dAzure.AppServices
 {
 	public sealed class ZumoRequest : RestRequest
 	{
-		public ZumoRequest (MobileServiceClient client, string url, Method httpMethod) : base (url, httpMethod)
+		public ZumoRequest (AppServiceClient client, string url, Method httpMethod) : base (url, httpMethod)
 		{
 			this.AddHeader ("ZUMO-API-VERSION", "2.0.0");
 			this.AddHeader ("Accept", "application/json");

--- a/Assets/AppServices/model/AppServiceUser.cs
+++ b/Assets/AppServices/model/AppServiceUser.cs
@@ -3,7 +3,7 @@
 namespace Unity3dAzure.AppServices
 {
 	[Serializable]
-	public class MobileServiceUser
+	public class AppServiceUser
 	{
 		public string authenticationToken;
 		public User user;

--- a/Assets/AppServices/table/MobileServiceTable.cs
+++ b/Assets/AppServices/table/MobileServiceTable.cs
@@ -6,12 +6,12 @@ namespace Unity3dAzure.AppServices
 {
 	public class MobileServiceTable<E> : IAzureMobileServiceTable
 	{
-		private MobileServiceClient _client;
+		private AppServiceClient _client;
 		private string _name;
         
 		public const string URI_TABLES = "tables/";
 
-		public MobileServiceTable (string tableName, MobileServiceClient client)
+		public MobileServiceTable (string tableName, AppServiceClient client)
 		{
 			_client = client;
 			_name = tableName; // NB: The table name could be infered from the Table's DataModel using typeof(E).Name; but passing Table name as a string allows for the case when the Classname is not the same as the Table name.

--- a/Assets/Scenes/HighscoresDemo.unity
+++ b/Assets/Scenes/HighscoresDemo.unity
@@ -1406,6 +1406,80 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &457228684
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 457228685}
+  - component: {fileID: 457228687}
+  - component: {fileID: 457228686}
+  m_Layer: 5
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &457228685
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 457228684}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1621202408}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &457228686
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 457228684}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Azure Function
+--- !u!222 &457228687
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 457228684}
 --- !u!1 &521206863
 GameObject:
   m_ObjectHideFlags: 0
@@ -2865,6 +2939,7 @@ RectTransform:
   m_Children:
   - {fileID: 1046828124}
   - {fileID: 947988036}
+  - {fileID: 1621202408}
   m_Father: {fileID: 845385617}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3284,7 +3359,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1064423870}
   m_HandleRect: {fileID: 1064423869}
   m_Direction: 0
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4274,10 +4349,132 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _appUrl: https://krist00fer.azurewebsites.net
-  _facebookAccessToken: EAAKQRUA5HgUBAJ2L8NJCwPgloxdpxK9wMCG5MJZBuFjJutveZBTVAuj5GQbDSVPcfmwcxwJXfIzbkbZApDwtRsX4X46ZAjcQ5VaivZBPhADEw5G7ASWzjZCfW7HjC7gZCTcJqVZC6RRafqqhTTPyflWyPjfHOtorqlgkAZAGGAyAsMe5Vp94tgmZAtWn5qQg5A9swZD
+  _facebookAccessToken: EAAKQRUA5HgUBAHTokKbVGFzDEpRpnTPZCjl6ZBgsAbVgcaHItbgNMNicTPDTeWJ1YQkCsiaUainampHBtXXe2cZAqtZCMsXE4uCMgBluZAdzRd4Rn3qb6ScxcQYV01klZBfqSZBeA1xu5UAooXeDNxqdflXCzbY0qxBJSdkmPLeE9chopOOmZCqHAKwMGFpMSkwZD
   _tableView: {fileID: 371080080}
   _cellPrefab: {fileID: 784713177}
   _modalAlert: {fileID: 1389452106}
+--- !u!1 &1621202407
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1621202408}
+  - component: {fileID: 1621202411}
+  - component: {fileID: 1621202410}
+  - component: {fileID: 1621202409}
+  m_Layer: 5
+  m_Name: Function
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1621202408
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1621202407}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 457228685}
+  m_Father: {fileID: 1103313610}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1621202409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1621202407}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1392445389, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1621202410}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1578968902}
+        m_MethodName: HelloFunction
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_TypeName: UnityEngine.UI.Button+ButtonClickedEvent, UnityEngine.UI, Version=1.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+--- !u!114 &1621202410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1621202407}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1621202411
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1621202407}
 --- !u!1 &1658579220
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/HighscoresDemo.unity
+++ b/Assets/Scenes/HighscoresDemo.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -41,7 +42,7 @@ RenderSettings:
 --- !u!157 &4
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -53,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 0
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -66,13 +67,27 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_UseShadowmask: 0
 --- !u!196 &5
 NavMeshSettings:
   serializedVersion: 2
@@ -89,6 +104,8 @@ NavMeshSettings:
     minRegionArea: 2
     manualCellSize: 0
     cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
 --- !u!1 &18042273
@@ -161,6 +178,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -1352,7 +1371,7 @@ Canvas:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 443289796}
   m_Enabled: 1
-  serializedVersion: 2
+  serializedVersion: 3
   m_RenderMode: 0
   m_Camera: {fileID: 0}
   m_PlaneDistance: 100
@@ -1361,6 +1380,7 @@ Canvas:
   m_OverrideSorting: 0
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -1816,7 +1836,7 @@ MonoBehaviour:
     m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 0
-    m_HorizontalOverflow: 0
+    m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
@@ -3264,7 +3284,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1064423870}
   m_HandleRect: {fileID: 1064423869}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4203,7 +4223,7 @@ MonoBehaviour:
     m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 0
-    m_HorizontalOverflow: 0
+    m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 
@@ -4253,8 +4273,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9dcdeb5277262475c858002ec725ae70, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _appUrl: YOUR_APP_URL
-  _facebookAccessToken: 
+  _appUrl: https://krist00fer.azurewebsites.net
+  _facebookAccessToken: EAAKQRUA5HgUBAJ2L8NJCwPgloxdpxK9wMCG5MJZBuFjJutveZBTVAuj5GQbDSVPcfmwcxwJXfIzbkbZApDwtRsX4X46ZAjcQ5VaivZBPhADEw5G7ASWzjZCfW7HjC7gZCTcJqVZC6RRafqqhTTPyflWyPjfHOtorqlgkAZAGGAyAsMe5Vp94tgmZAtWn5qQg5A9swZD
   _tableView: {fileID: 371080080}
   _cellPrefab: {fileID: 784713177}
   _modalAlert: {fileID: 1389452106}
@@ -5145,7 +5165,7 @@ MonoBehaviour:
     m_Alignment: 3
     m_AlignByGeometry: 0
     m_RichText: 0
-    m_HorizontalOverflow: 0
+    m_HorizontalOverflow: 1
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 

--- a/Assets/Scripts/HighscoresDemo.cs
+++ b/Assets/Scripts/HighscoresDemo.cs
@@ -26,7 +26,7 @@ public class HighscoresDemo : MonoBehaviour, ITableViewDataSource
 	private string _facebookAccessToken = "";
 
 	// App Service Rest Client
-	private MobileServiceClient _client;
+	private AppServiceClient _client;
 
 	// App Service Table defined using a DataModel
 	private MobileServiceTable<Highscore> _table;
@@ -66,7 +66,7 @@ public class HighscoresDemo : MonoBehaviour, ITableViewDataSource
 	void Start ()
 	{
 		// Create App Service client
-		_client = new MobileServiceClient (_appUrl);
+		_client = new AppServiceClient (_appUrl);
 
 		// Get App Service 'Highscores' table
 		_table = _client.GetTable<Highscore> ("Highscores");
@@ -94,7 +94,7 @@ public class HighscoresDemo : MonoBehaviour, ITableViewDataSource
 			SetInteractableScrollbars (true);
 			HasNewData = false;
 		}
-		// Display new score details 
+		// Display new score details
 		if (_score != null) {
 			Debug.Log ("Show score:" + _score.ToString ());
 			DisplayScore (_score);
@@ -110,15 +110,15 @@ public class HighscoresDemo : MonoBehaviour, ITableViewDataSource
 
 	public void Login ()
 	{
-		StartCoroutine (_client.Login (MobileServiceAuthenticationProvider.Facebook, _facebookAccessToken, OnLoginCompleted));
+		StartCoroutine (_client.Login (AppServiceAuthenticationProvider.Facebook, _facebookAccessToken, OnLoginCompleted));
 	}
 
-	private void OnLoginCompleted (IRestResponse<MobileServiceUser> response)
+	private void OnLoginCompleted (IRestResponse<AppServiceUser> response)
 	{
 		Debug.Log ("OnLoginCompleted: " + response.Content + " Url:" + response.Url);
 
 		if (!response.IsError && response.StatusCode == HttpStatusCode.OK) {
-			MobileServiceUser mobileServiceUser = response.Data;
+			AppServiceUser mobileServiceUser = response.Data;
 			_client.User = mobileServiceUser;
 			Debug.Log ("Authorized UserId: " + _client.User.user.userId);
 		} else {
@@ -295,6 +295,11 @@ public class HighscoresDemo : MonoBehaviour, ITableViewDataSource
 		StartCoroutine (_client.InvokeApi<Message> ("hello", Method.GET, OnCustomApiCompleted));
 	}
 
+	public void HelloFunction()
+	{
+		StartCoroutine (_client.InvokeApi<Message> ("LeaderBoard?code=fEajfD2lrmOwILZtNcOFAA9OVaJmgPheBfa6/2gMakPkSGRobym1Uw==", Method.GET, OnCustomApiCompleted));
+	}
+
 	public void GenerateScores ()
 	{
 		StartCoroutine (_client.InvokeApi<Message> ("GenerateScores", Method.POST, OnCustomApiCompleted));
@@ -337,7 +342,7 @@ public class HighscoresDemo : MonoBehaviour, ITableViewDataSource
 	}
 
 	/// <summary>
-	/// Update UI with data model 
+	/// Update UI with data model
 	/// </summary>
 	private void DisplayScore (Highscore highscore)
 	{

--- a/Assets/Scripts/InventoryDemo.cs
+++ b/Assets/Scripts/InventoryDemo.cs
@@ -36,7 +36,7 @@ public class InventoryDemo : MonoBehaviour, ITableViewDataSource
 	private string _facebookAccessToken = "";
 
 	// App Service Rest Client
-	private MobileServiceClient _client;
+	private AppServiceClient _client;
 
 	// App Service Table defined using a DataModel
 	private MobileServiceTable<Inventory> _table;
@@ -68,7 +68,7 @@ public class InventoryDemo : MonoBehaviour, ITableViewDataSource
 	void Start ()
 	{
 		// Create App Service client
-		_client = new MobileServiceClient (_appUrl);
+		_client = new AppServiceClient (_appUrl);
 
 		// Get App Service 'Highscores' table
 		_table = _client.GetTable<Inventory> ("Inventory");
@@ -124,14 +124,14 @@ public class InventoryDemo : MonoBehaviour, ITableViewDataSource
 
 	public void Login ()
 	{
-		StartCoroutine (_client.Login (MobileServiceAuthenticationProvider.Facebook, _facebookAccessToken, OnLoginCompleted));
+		StartCoroutine (_client.Login (AppServiceAuthenticationProvider.Facebook, _facebookAccessToken, OnLoginCompleted));
 	}
 
-	private void OnLoginCompleted (IRestResponse<MobileServiceUser> response)
+	private void OnLoginCompleted (IRestResponse<AppServiceUser> response)
 	{
 		if (!response.IsError) {
 			Debug.Log ("OnLoginCompleted: " + response.Content + " Status: " + response.StatusCode + " Url:" + response.Url);
-			MobileServiceUser mobileServiceUser = response.Data;
+			AppServiceUser mobileServiceUser = response.Data;
 			_client.User = mobileServiceUser;
 			Debug.Log ("Authorized UserId: " + _client.User.user.userId);
 			DidLogin = true;

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 10
+  serializedVersion: 12
   productGUID: 2d980679b11fa446d9d20f5a821d2147
   AndroidProfiler: 0
   defaultScreenOrientation: 4
@@ -14,7 +14,7 @@ PlayerSettings:
   productName: AppServicesDemo
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
-  m_SplashScreenBackgroundColor: {r: 0.13333334, g: 0.17254902, b: 0.21176471, a: 1}
+  m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
   m_ShowUnitySplashScreen: 1
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
@@ -70,12 +70,14 @@ PlayerSettings:
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
+  Force IOS Speakers When Recording: 0
   submitAnalytics: 1
   usePlayerLog: 1
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   resizableWindow: 0
   useMacAppStoreValidation: 0
+  macAppStoreCategory: public.app-category.games
   gpuSkinning: 0
   graphicsJobs: 0
   xboxPIXTextureCapture: 0
@@ -85,6 +87,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 0
   allowFullscreenSwitch: 1
+  graphicsJobMode: 0
   macFullscreenMode: 2
   d3d9FullscreenMode: 1
   d3d11FullscreenMode: 1
@@ -95,11 +98,11 @@ PlayerSettings:
   n3dsDisableStereoscopicView: 0
   n3dsEnableSharedListOpt: 1
   n3dsEnableVSync: 0
-  uiUse16BitDepthBuffer: 0
   ignoreAlphaClear: 0
   xboxOneResolution: 0
   xboxOneMonoLoggingLevel: 0
   xboxOneLoggingLevel: 1
+  xboxOneDisableEsram: 0
   videoMemoryForVertexBuffers: 0
   psp2PowerMode: 0
   psp2AcquireBGM: 1
@@ -118,27 +121,46 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleIdentifier: net.deadlyfingers.Unity3DAzure
   bundleVersion: 1.0
   preloadedAssets: []
   metroInputSource: 0
   m_HolographicPauseOnTrackingLoss: 1
   xboxOneDisableKinectGpuReservation: 0
+  xboxOneEnable7thCore: 0
+  vrSettings:
+    cardboard:
+      depthFormat: 0
+      enableTransitionView: 0
+    daydream:
+      depthFormat: 0
+      useSustainedPerformanceMode: 0
+    hololens:
+      depthFormat: 1
   protectGraphicsMemory: 0
+  useHDRDisplay: 0
+  targetPixelDensity: 0
+  resolutionScalingMode: 0
+  applicationIdentifier:
+    Android: net.deadlyfingers.Unity3DAzure
+    Standalone: unity.DefaultCompany.AppServicesDemo
+    Tizen: net.deadlyfingers.Unity3DAzure
+    iOS: net.deadlyfingers.Unity3DAzure
+    tvOS: net.deadlyfingers.Unity3DAzure
+  buildNumber:
+    iOS: 0
   AndroidBundleVersionCode: 1
-  AndroidMinSdkVersion: 9
+  AndroidMinSdkVersion: 16
+  AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
-  apiCompatibilityLevel: 2
   stripEngineCode: 1
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
-  iPhoneBuildNumber: 0
   ForceInternetPermission: 1
   ForceSDCardPermission: 0
   CreateWallpaper: 0
   APKExpansionFiles: 0
-  preloadShaders: 0
+  keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
   VertexChannelCompressionMask:
     serializedVersion: 2
@@ -190,7 +212,13 @@ PlayerSettings:
   iOSURLSchemes: []
   iOSBackgroundModes: 0
   iOSMetalForceHardShadows: 0
+  metalEditorSupport: 1
+  metalAPIValidation: 1
+  iOSRenderExtraFrameOnPause: 1
   appleDeveloperTeamID: 
+  iOSManualSigningProvisioningProfileID: 
+  tvOSManualSigningProvisioningProfileID: 
+  appleEnableAutomaticSigning: 0
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -291,6 +319,7 @@ PlayerSettings:
   wiiUGamePadStartupScreen: {fileID: 0}
   wiiUDrcBufferDisabled: 0
   wiiUProfilerLibPath: 
+  playModeTestRunnerEnabled: 0
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
@@ -298,16 +327,113 @@ PlayerSettings:
   cameraUsageDescription: 
   locationUsageDescription: 
   microphoneUsageDescription: 
-  XboxTitleId: 
-  XboxImageXexPath: 
-  XboxSpaPath: 
-  XboxGenerateSpa: 0
-  XboxDeployKinectResources: 0
-  XboxSplashScreen: {fileID: 0}
-  xboxEnableSpeech: 0
-  xboxAdditionalTitleMemorySize: 0
-  xboxDeployKinectHeadOrientation: 0
-  xboxDeployKinectHeadPosition: 0
+  switchNetLibKey: 
+  switchSocketMemoryPoolSize: 6144
+  switchSocketAllocatorPoolSize: 128
+  switchSocketConcurrencyLimit: 14
+  switchScreenResolutionBehavior: 2
+  switchUseCPUProfiler: 0
+  switchApplicationID: 0x01004b9000490000
+  switchNSODependencies: 
+  switchTitleNames_0: 
+  switchTitleNames_1: 
+  switchTitleNames_2: 
+  switchTitleNames_3: 
+  switchTitleNames_4: 
+  switchTitleNames_5: 
+  switchTitleNames_6: 
+  switchTitleNames_7: 
+  switchTitleNames_8: 
+  switchTitleNames_9: 
+  switchTitleNames_10: 
+  switchTitleNames_11: 
+  switchPublisherNames_0: 
+  switchPublisherNames_1: 
+  switchPublisherNames_2: 
+  switchPublisherNames_3: 
+  switchPublisherNames_4: 
+  switchPublisherNames_5: 
+  switchPublisherNames_6: 
+  switchPublisherNames_7: 
+  switchPublisherNames_8: 
+  switchPublisherNames_9: 
+  switchPublisherNames_10: 
+  switchPublisherNames_11: 
+  switchIcons_0: {fileID: 0}
+  switchIcons_1: {fileID: 0}
+  switchIcons_2: {fileID: 0}
+  switchIcons_3: {fileID: 0}
+  switchIcons_4: {fileID: 0}
+  switchIcons_5: {fileID: 0}
+  switchIcons_6: {fileID: 0}
+  switchIcons_7: {fileID: 0}
+  switchIcons_8: {fileID: 0}
+  switchIcons_9: {fileID: 0}
+  switchIcons_10: {fileID: 0}
+  switchIcons_11: {fileID: 0}
+  switchSmallIcons_0: {fileID: 0}
+  switchSmallIcons_1: {fileID: 0}
+  switchSmallIcons_2: {fileID: 0}
+  switchSmallIcons_3: {fileID: 0}
+  switchSmallIcons_4: {fileID: 0}
+  switchSmallIcons_5: {fileID: 0}
+  switchSmallIcons_6: {fileID: 0}
+  switchSmallIcons_7: {fileID: 0}
+  switchSmallIcons_8: {fileID: 0}
+  switchSmallIcons_9: {fileID: 0}
+  switchSmallIcons_10: {fileID: 0}
+  switchSmallIcons_11: {fileID: 0}
+  switchManualHTML: 
+  switchAccessibleURLs: 
+  switchLegalInformation: 
+  switchMainThreadStackSize: 1048576
+  switchPresenceGroupId: 0x01004b9000490000
+  switchLogoHandling: 0
+  switchReleaseVersion: 0
+  switchDisplayVersion: 1.0.0
+  switchStartupUserAccount: 0
+  switchTouchScreenUsage: 0
+  switchSupportedLanguagesMask: 0
+  switchLogoType: 0
+  switchApplicationErrorCodeCategory: 
+  switchUserAccountSaveDataSize: 0
+  switchUserAccountSaveDataJournalSize: 0
+  switchApplicationAttribute: 0
+  switchCardSpecSize: 4
+  switchCardSpecClock: 25
+  switchRatingsMask: 0
+  switchRatingsInt_0: 0
+  switchRatingsInt_1: 0
+  switchRatingsInt_2: 0
+  switchRatingsInt_3: 0
+  switchRatingsInt_4: 0
+  switchRatingsInt_5: 0
+  switchRatingsInt_6: 0
+  switchRatingsInt_7: 0
+  switchRatingsInt_8: 0
+  switchRatingsInt_9: 0
+  switchRatingsInt_10: 0
+  switchRatingsInt_11: 0
+  switchLocalCommunicationIds_0: 0x01004b9000490000
+  switchLocalCommunicationIds_1: 
+  switchLocalCommunicationIds_2: 
+  switchLocalCommunicationIds_3: 
+  switchLocalCommunicationIds_4: 
+  switchLocalCommunicationIds_5: 
+  switchLocalCommunicationIds_6: 
+  switchLocalCommunicationIds_7: 
+  switchParentalControl: 0
+  switchAllowsScreenshot: 1
+  switchDataLossConfirmation: 0
+  switchSupportedNpadStyles: 3
+  switchSocketConfigEnabled: 0
+  switchTcpInitialSendBufferSize: 32
+  switchTcpInitialReceiveBufferSize: 64
+  switchTcpAutoSendBufferSizeMax: 256
+  switchTcpAutoReceiveBufferSizeMax: 256
+  switchUdpSendBufferSize: 9
+  switchUdpReceiveBufferSize: 42
+  switchSocketBufferEfficiency: 4
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -320,6 +446,7 @@ PlayerSettings:
   ps4ParamSfxPath: 
   ps4VideoOutPixelFormat: 0
   ps4VideoOutInitialWidth: 1920
+  ps4VideoOutBaseModeInitialWidth: 1920
   ps4VideoOutReprojectionRate: 120
   ps4PronunciationXMLPath: 
   ps4PronunciationSIGPath: 
@@ -342,8 +469,8 @@ PlayerSettings:
   ps4ApplicationParam4: 0
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
+  ps4ProGarlicHeapSize: 2560
   ps4Passcode: 5PN2qmWqBlQ9wQj99nsQzldVI5ZuGXbE
-  ps4UseDebugIl2cppLibs: 0
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1
@@ -367,6 +494,9 @@ PlayerSettings:
   ps4attribShareSupport: 0
   ps4attribExclusiveVR: 0
   ps4disableAutoHideSplash: 0
+  ps4videoRecordingFeaturesUsed: 0
+  ps4contentSearchFeaturesUsed: 0
+  ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
   monoEnv: 
   psp2Splashimage: {fileID: 0}
@@ -415,13 +545,14 @@ PlayerSettings:
   psp2UseLibLocation: 0
   psp2InfoBarOnStartup: 0
   psp2InfoBarColor: 0
-  psp2UseDebugIl2cppLibs: 0
+  psp2ScriptOptimizationLevel: 0
   psmSplashimage: {fileID: 0}
   splashScreenBackgroundSourceLandscape: {fileID: 0}
   splashScreenBackgroundSourcePortrait: {fileID: 0}
   spritePackerPolicy: 
   webGLMemorySize: 256
   webGLExceptionSupport: 1
+  webGLNameFilesAsHashes: 0
   webGLDataCaching: 0
   webGLDebugSymbols: 0
   webGLEmscriptenArgs: 
@@ -447,6 +578,8 @@ PlayerSettings:
     iOS: 1
     tvOS: 0
   additionalIl2CppArgs: 
+  scriptingRuntimeVersion: 0
+  apiCompatibilityLevelPerPlatform: {}
   m_RenderingPath: 1
   m_MobileRenderingPath: 1
   metroPackageName: net.deadlyfingers.Unity3dAzureDemo
@@ -506,7 +639,7 @@ PlayerSettings:
   tizenMicrophonePermissions: 0
   tizenDeploymentTarget: 
   tizenDeploymentTargetType: 0
-  tizenMinOSVersion: 0
+  tizenMinOSVersion: 1
   n3dsUseExtSaveData: 0
   n3dsCompressStaticMem: 1
   n3dsExtSaveDataNumber: 0x12345
@@ -546,7 +679,11 @@ PlayerSettings:
   XboxOneSplashScreen: {fileID: 0}
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
-  vrEditorSettings: {}
+  xboxOneScriptCompiler: 0
+  vrEditorSettings:
+    daydream:
+      daydreamIconForeground: {fileID: 0}
+      daydreamIconBackground: {fileID: 0}
   cloudServicesEnabled:
     Analytics: 0
     Build: 0
@@ -557,7 +694,11 @@ PlayerSettings:
     Purchasing: 0
     UNet: 0
     Unity_Ads: 0
+  facebookSdkVersion: 7.9.4
+  apiCompatibilityLevel: 2
   cloudProjectId: 
   projectName: 
   organizationId: 
   cloudEnabled: 0
+  enableNativePlatformBackendsForNewInputSystem: 0
+  disableOldInputManagerSupport: 0

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.5.0f3
+m_EditorVersion: 2017.1.0f3


### PR DESCRIPTION
I want to re-use the code in this library to call APIs implemented in Azure functions. The current Unity Code has a lot of references to Mobile Apps inside AppService even if the same implementation and classes can be used to call an API implemented in Azure Functions.

I propose that we try to evolve the AppService Unity Library to be more generic and to enable calling of Azure Functions.

This first pull request is targeting the "Demo Project" since I'd love your feedback on the changes I've done and it's more easy to discuss with a few demo scenes setup in Unity. Once we can come to an agreement I'm more than happy to submit the same changes to the other repository.

If you agree with me, then I see only a few more things that needs to be done in order to fully support my needs while calling Azure Function APIs like: Even more easy passing of parameters, calling Azure Functions that are "protected" by a code (can be worked around today by passing in the code in the name, but that could be done easier).

I'm very impressed with the work you've done so far